### PR TITLE
Adjust headers to get correct digests

### DIFF
--- a/tag/registry/registry.go
+++ b/tag/registry/registry.go
@@ -16,6 +16,7 @@ func httpRequest(url, authorization string) (*http.Response, error) {
 	}
 
 	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
 
 	resp, err := hc.Do(req)
 	if err != nil {


### PR DESCRIPTION
From
https://stackoverflow.com/questions/37758258/is-that-possible-to-get-image-id-from-docker-registry-v2#

