### PR TITLE
Sort by DateTime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
-
-# Compiled binary
+# Compiled binaries
 /lstags
+/lstags.*
 
 # Vendored dependencies
 /vendor/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - make dep
 
 script:
+  - make unit-test
   - make package-test
   - make integration-test
   - make lint

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ package-test:
 integration-test:
 	go test -integration -v
 
-lint: ERRORS=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -i golint {})
+lint: ERRORS:=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -i golint {})
 lint: fail-on-errors
 
-vet: ERRORS=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -i go tool vet {})
+vet: ERRORS:=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -i go tool vet {})
 vet: fail-on-errors
 
 fail-on-errors:
@@ -34,3 +34,13 @@ fail-on-errors:
 
 build:
 	go build
+
+build-linux: GOOS:=linux
+build-linux:
+	GOOS=${GOOS} go build -o lstags.${GOOS}
+
+build-darwin: GOOS:=darwin
+build-darwin:
+	GOOS=${GOOS} go build -o lstags.${GOOS}
+
+xbuild: build-linux build-darwin

--- a/main.go
+++ b/main.go
@@ -63,12 +63,14 @@ func main() {
 		suicide(err)
 	}
 
-	sortKeys, joinedTags := tag.Join(registryTags, localTags)
+	sortedKeys, names, joinedTags := tag.Join(registryTags, localTags)
 
 	const format = "%-12s %-45s %-15s %-25s %s\n"
 	fmt.Printf(format, "<STATE>", "<DIGEST>", "<(local) ID>", "<Created At>", "<TAG>")
-	for _, sortKey := range sortKeys {
-		tg := joinedTags[sortKey]
+	for _, key := range sortedKeys {
+		name := names[key]
+
+		tg := joinedTags[name]
 
 		fmt.Printf(
 			format,

--- a/main_test.go
+++ b/main_test.go
@@ -30,6 +30,11 @@ func (tr MockedTokenResponse) ExpiresIn() int {
 }
 
 func TestGetAuthorization(t *testing.T) {
+	flag.Parse()
+	if *runIntegrationTests {
+		t.SkipNow()
+	}
+
 	const expected = "Mocked 8c896241e2774507489849ab1981e582"
 
 	authorization := getAuthorization(MockedTokenResponse{})

--- a/tag/local/local.go
+++ b/tag/local/local.go
@@ -132,7 +132,7 @@ func FetchTags(repo string) (map[string]*tag.Tag, error) {
 
 			tg.SetCreated(imageSummary.Created)
 
-			tags[tg.SortKey()] = tg
+			tags[tg.GetName()] = tg
 		}
 	}
 

--- a/tag/registry/registry.go
+++ b/tag/registry/registry.go
@@ -310,7 +310,7 @@ func FetchTags(registry, repo, authorization string, concurrency int) (map[strin
 
 			tt.SetCreated(dr.Created)
 
-			tags[tt.SortKey()] = tt
+			tags[tt.GetName()] = tt
 		}
 	}
 

--- a/tag/tag_test.go
+++ b/tag/tag_test.go
@@ -108,7 +108,7 @@ func localTags() map[string]*Tag {
 func TestJoinLength(t *testing.T) {
 	const expected = 4
 
-	_, tags := Join(registryTags(), localTags())
+	_, _, tags := Join(registryTags(), localTags())
 
 	c := len(tags)
 
@@ -129,7 +129,7 @@ func TestJoinDigest(t *testing.T) {
 		"v1.2":   "sha256:7f7f94f26d23f7aca80a33732161af068f9f62fbe0e824a58cf3a39d209cfa77",
 	}
 
-	_, tags := Join(registryTags(), localTags())
+	_, _, tags := Join(registryTags(), localTags())
 
 	for name, digest := range expected {
 		if tags[name].GetDigest() != digest {
@@ -151,7 +151,7 @@ func TestJoinImageID(t *testing.T) {
 		"v1.2":   "4c4ebb9614ef",
 	}
 
-	_, tags := Join(registryTags(), localTags())
+	_, _, tags := Join(registryTags(), localTags())
 
 	for name, imageID := range expected {
 		if tags[name].GetImageID() != imageID {
@@ -173,7 +173,7 @@ func TestJoinState(t *testing.T) {
 		"v1.2":   "PRESENT",
 	}
 
-	_, tags := Join(registryTags(), localTags())
+	_, _, tags := Join(registryTags(), localTags())
 
 	for name, state := range expected {
 		if tags[name].GetState() != state {


### PR DESCRIPTION
Sort by image creation datetime rather than by tag name.

Also separated naming and sort abstractions, which is good indeed.

Addressing this: https://github.com/ivanilves/lstags/issues/27 :tada: 

# GIF
![](https://media.giphy.com/media/xUA7b68hKy839wiVJC/giphy.gif)