### PR TITLE
Push in a more intelligent manner

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,16 @@ You could use `lstags`, if you ...
 * ... poll registry for the new images pushed (to take some action afterwards, run CI for example).
 * ... compare local images with registry ones (e.g. know, if image tagged "latest" was re-pushed).
 
-## How do I use it myself?
-I run `lstags` inside a Cron Job on my Kubernetes worker nodes to poll my own Docker registry for a new [stable] images.
+... pull Ubuntu 14.04 & 16.04, all the Alpine images and Debian "stretch" to have latest software to play with:
 ```
-lstags --pull registry.ivanilves.local/tools/sicario~/v1\\.[0-9]+$/
+lstags --pull ubuntu~/^1[46]\\.04$/ alpine debian~/stretch/
+```
+... pull and re-push CoreOS-related images from `quay.io` to your own registry (in case these hipsters will break everything):
+```
+lstags --push-prefix=/quay --push-registry=registry.company.io quay.io/coreos/hyperkube quay.io/coreos/flannel
 ```
 **NB!** In case you use private registry with authentication, make sure your Docker client knows how to authenticate against it!
 `lstags` will reuse credentials saved by Docker client in its `config.json` file, one usually found at `~/.docker/config.json`
-
-... and following cronjob runs on my CI server to ensure I always have latest Ubuntu 14.04 and 16.04 images to play with:
-```
-lstags --pull ubuntu~/^1[46]\\.04$/
-```
-My CI server is connected over crappy Internet link and pulling images in advance makes `docker run` much faster. :wink:
 
 ## Image state
 `lstags` distinguishes four states of Docker image:
@@ -55,7 +52,6 @@ There is also special `UNKNOWN` state, which means `lstags` failed to detect ima
 You can either:
 * rely on `lstags` discovering credentials "automagically" :tophat:
 * load credentials from any Docker JSON config file specified
-* pass username and password explicitly, via the command line
 
 ## Install: Binaries
 https://github.com/ivanilves/lstags/releases

--- a/main.go
+++ b/main.go
@@ -118,6 +118,8 @@ func main() {
 			repoPath := docker.GetRepoPath(repository, registry)
 			repoName := docker.GetRepoName(repository, registry)
 
+			fmt.Printf("ANALYZE %s\n", repoName)
+
 			username, password, _ := dockerConfig.GetCredentials(registry)
 
 			tr, err := auth.NewToken(registry, repoPath, username, password)
@@ -221,6 +223,8 @@ func main() {
 
 	r := 0
 	for tc := range tcc {
+		fmt.Printf("FETCHED %s\n", tc.RepoName)
+
 		tagCollections = append(tagCollections, tc)
 		r++
 
@@ -230,6 +234,7 @@ func main() {
 	}
 
 	const format = "%-12s %-45s %-15s %-25s %s\n"
+	fmt.Printf("-\n")
 	fmt.Printf(format, "<STATE>", "<DIGEST>", "<(local) ID>", "<Created At>", "<TAG>")
 	for _, tc := range tagCollections {
 		for _, tg := range tc.Tags {

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 				suicide(err, true)
 			}
 
-			remoteTags, err := remote.FetchTags(registry, repoPath, tr.AuthHeader(), o.ConcurrentRequests)
+			remoteTags, err := remote.FetchTags(registry, repoPath, tr.AuthHeader(), o.ConcurrentRequests, filter)
 			if err != nil {
 				suicide(err, true)
 			}
@@ -179,7 +179,7 @@ func main() {
 					suicide(err, true)
 				}
 
-				alreadyPushedTags, err := remote.FetchTags(o.PushRegistry, pushRepoPath, tr.AuthHeader(), o.ConcurrentRequests)
+				alreadyPushedTags, err := remote.FetchTags(o.PushRegistry, pushRepoPath, tr.AuthHeader(), o.ConcurrentRequests, filter)
 				if err != nil {
 					if !strings.Contains(err.Error(), "404 Not Found") {
 						suicide(err, true)

--- a/main_test.go
+++ b/main_test.go
@@ -29,7 +29,7 @@ func TestDockerHubWithPublicRepo(t *testing.T) {
 		t.Fatalf("Failed to get DockerHub public repo token: %s", err.Error())
 	}
 
-	tags, err := remote.FetchTags(dockerHub, repo, tr.AuthHeader(), 128)
+	tags, err := remote.FetchTags(dockerHub, repo, tr.AuthHeader(), 128, ".*")
 	if err != nil {
 		t.Fatalf("Failed to list DockerHub public repo (%s) tags: %s", repo, err.Error())
 	}
@@ -60,7 +60,7 @@ func TestDockerHubWithPrivateRepo(t *testing.T) {
 		t.Fatalf("Failed to get DockerHub private repo token: %s", err.Error())
 	}
 
-	tags, err := remote.FetchTags(dockerHub, repo, tr.AuthHeader(), 128)
+	tags, err := remote.FetchTags(dockerHub, repo, tr.AuthHeader(), 128, ".*")
 	if err != nil {
 		t.Fatalf("Failed to list DockerHub private repo (%s) tags: %s", repo, err.Error())
 	}

--- a/tag/remote/remote.go
+++ b/tag/remote/remote.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ivanilves/lstags/tag"
+	"github.com/ivanilves/lstags/util"
 )
 
 // WebSchema defines how do we connect to remote web servers
@@ -270,15 +271,22 @@ func calculateBatchStepSize(stepNumber, stepsTotal, remain, limit int) int {
 }
 
 // FetchTags looks up Docker repo tags present on remote Docker registry
-func FetchTags(registry, repo, authorization string, concurrentRequests int) (map[string]*tag.Tag, error) {
+func FetchTags(registry, repo, authorization string, concurrentRequests int, filter string) (map[string]*tag.Tag, error) {
 	batchLimit, err := validateConcurrentRequests(concurrentRequests)
 	if err != nil {
 		return nil, err
 	}
 
-	tagNames, err := fetchTagNames(registry, repo, authorization)
+	allTagNames, err := fetchTagNames(registry, repo, authorization)
 	if err != nil {
 		return nil, err
+	}
+
+	tagNames := make([]string, 0)
+	for _, tagName := range allTagNames {
+		if util.DoesMatch(tagName, filter) {
+			tagNames = append(tagNames, tagName)
+		}
 	}
 
 	tags := make(map[string]*tag.Tag)


### PR DESCRIPTION
### No need to download the whole Internet now!
![](https://media.giphy.com/media/BYjZcTb5E2YoM/giphy.gif)
Brand new "registry<=>registry" image comparison algorithm
for Docker push instead of handicapped "docker<=>registry". :rocket: 

### NB!
* Due to new algorithm, options `--pull` and `--push` are conflicting now! :warning: 
* Update tags with changed digests or not? Option `push-update` will help :wink:  

# GIF
![](https://media.giphy.com/media/SZpxRhQYqBDsA/giphy.gif)