### PR TITLE
Added handling for possibly corrupt configs

### DIFF
--- a/docker/config/config.go
+++ b/docker/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -73,7 +74,25 @@ func Load(fileName string) (*Config, error) {
 			return nil, err
 		}
 
-		usernameAndPassword := strings.Split(string(b), ":")
+		authenticationToken := string(b)
+		usernameAndPassword := strings.Split(authenticationToken, ":")
+
+		if len(usernameAndPassword) != 2 {
+			if fileName != DefaultDockerJSON {
+				errStr := "Invalid auth for Docker registry: %s\nBase64-encoded string is wrong: %s (%s)\n"
+
+				return nil, errors.New(
+					fmt.Sprint(
+						errStr,
+						registry,
+						a.B64Auth,
+						authenticationToken,
+					),
+				)
+			}
+
+			continue
+		}
 
 		c.usernames[registry] = usernameAndPassword[0]
 		c.passwords[registry] = usernameAndPassword[1]

--- a/fixtures/docker/config.json.corrupt
+++ b/fixtures/docker/config.json.corrupt
@@ -1,0 +1,10 @@
+{
+	"auths": {
+		"registry.galicia.io": {
+			"auth": "ZnJhbmNvOmZyYW5jbw=="
+		},
+		"registry.valencia.io": {
+			"auth": "bWFjb3N1YXU="
+		}
+  }
+}


### PR DESCRIPTION
Trying to fix: https://github.com/ivanilves/lstags/issues/87

# GIF
![](https://media.giphy.com/media/3o6EhKkXP6icIWbY9q/giphy.gif)