### PR TITLE
Add direct support for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# This file is a template, and might need editing before it works on your project.
+FROM golang:1.8-alpine AS builder
+# We'll likely need to add SSL root certificates
+RUN apk --no-cache add ca-certificates
+# Missing part for compiling the application by it self because it requires a sock
+FROM scratch
+# Since we started from scratch, we'll copy the SSL root certificates from the builder
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY lstags /usr/local/bin/lstags
+ENTRYPOINT [ "/usr/local/bin/lstags" ]
+CMD ["--help"]

--- a/Makefile
+++ b/Makefile
@@ -80,8 +80,8 @@ fail-on-errors:
 	@test `echo "${ERRORS}" | grep . | wc -l` -eq 0
 
 build:
-	@if [[ -z "${GOOS}" ]]; then go build; fi
-	@if [[ -n "${GOOS}" ]]; then mkdir -p dist/assets/lstags-${GOOS}; GOOS=${GOOS} go build -o dist/assets/lstags-${GOOS}/lstags; fi
+	@if [[ -z "${GOOS}" ]]; then go build -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo; fi
+	@if [[ -n "${GOOS}" ]]; then mkdir -p dist/assets/lstags-${GOOS}; GOOS=${GOOS} go build -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o dist/assets/lstags-${GOOS}/lstags; fi
 
 xbuild:
 	${MAKE} --no-print-directory build GOOS=linux

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: docker
+
 all: prepare dep test lint vet build
 
 offline: unit-test lint vet build
@@ -118,3 +120,7 @@ deploy:
 	test -n "${GITHUB_TOKEN}" && git tag ${TAG} && git push --tags
 	GITHUB_TOKEN=${GITHUB_TOKEN} ./scripts/github-create-release.sh ./dist/release
 	GITHUB_TOKEN=${GITHUB_TOKEN} ./scripts/github-upload-assets.sh ${TAG} ./dist/assets
+
+docker:
+	@docker container run -v $(shell pwd):/go/src/github.com/ivanilves/lstags -w /go/src/github.com/ivanilves/lstags -v /var/run/docker.sock:/var/run/docker.sock golang:1.8 scripts/prepare-docker-build.sh
+	@docker image build -t ivanilves/lstags .

--- a/README.md
+++ b/README.md
@@ -67,3 +67,58 @@ go build
 ./lstags -h
 ```
 **NB!** I assume you have current versions of Go & [dep](https://github.com/golang/dep) installed and also have set up [GOPATH](https://github.com/golang/go/wiki/GOPATH) correctly.
+
+## Using it with docker
+
+```sh
+docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock ivanilves/lstags
+Usage:
+  lstags [OPTIONS] REPO1 REPO2 REPOn...
+
+Application Options:
+  -j, --docker-json=          JSON file with credentials (default:
+                              ~/.docker/config.json) [$DOCKER_JSON]
+  -p, --pull                  Pull Docker images matched by filter (will use
+                              local Docker deamon) [$PULL]
+  -P, --push                  Push Docker images matched by filter to some
+                              registry (See 'push-registry') [$PUSH]
+  -r, --push-registry=        [Re]Push pulled images to a specified remote
+                              registry [$PUSH_REGISTRY]
+  -R, --push-prefix=          [Re]Push pulled images with a specified repo path
+                              prefix [$PUSH_PREFIX]
+  -U, --push-update           Update our pushed images if remote image digest
+                              changes [$PUSH_UPDATE]
+  -c, --concurrent-requests=  Limit of concurrent requests to the registry
+                              (default: 32) [$CONCURRENT_REQUESTS]
+  -I, --insecure-registry-ex= Expression to match insecure registry hostnames
+                              [$INSECURE_REGISTRY_EX]
+  -T, --trace-requests        Trace Docker registry HTTP requests
+                              [$TRACE_REQUESTS]
+  -N, --do-not-fail           Do not fail on non-critical errors (could be
+                              dangerous!) [$DO_NOT_FAIL]
+  -V, --version               Show version and exit
+
+Help Options:
+  -h, --help                  Show this help message
+
+Arguments:
+  REPO1 REPO2 REPOn:          Docker repositories to operate on, e.g.: alpine
+                              nginx~/1\.13\.5$/ busybox~/1.27.2/
+```
+
+### Analyze an image
+
+```sh
+docker run --rm -it  -v /var/run/docker.sock:/var/run/docker.sock ivanilves/lstags alpine~/^3\\./
+ANALYZE alpine
+FETCHED alpine
+-
+<STATE>      <DIGEST>                                      <(local) ID>    <Created At>              <TAG>
+CHANGED      sha256:b40e202395eaec699f2d0c5e01e6d6cb8      76da55c8019d    2017-10-25T23:19:51Z      alpine:3.6
+ABSENT       sha256:d95da16498d5d6fb4b907cbe013f95032      n/a             2017-10-25T23:20:18Z      alpine:3.1
+ABSENT       sha256:cb275b62f789b211114f28b391fca3cc2      n/a             2017-10-25T23:20:32Z      alpine:3.2
+ABSENT       sha256:27af7da847283a947c008592f2b2cd6d2      n/a             2017-10-25T23:20:45Z      alpine:3.3
+CHANGED      sha256:246bbbaa81b28837b64cb9dfc574de958      1a19a71e5d38    2017-10-25T23:20:59Z      alpine:3.4
+CHANGED      sha256:aa96c8dc3815c44d4aceaf1ee7903ce58      37c7be7a096b    2017-10-25T23:21:13Z      alpine:3.5
+-
+```

--- a/scripts/prepare-docker-build.sh
+++ b/scripts/prepare-docker-build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Workaround because the Makefile doesn't recognize the bash
+# This should be fixed in the Makefile and not in the directory    
+ln -nfs /bin/bash /bin/sh
+make all


### PR DESCRIPTION
Hey @ivanilves,
awesome project 💯 . I added a Dockerfile so that you can use your tool directly with docker. In future it would be great to have an tcp option for the docker engine. This would enable multistage builds and not the current workaround.