### PR TITLE
Assume [some] tag names are present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ blackbox-integration-test: build \
 	shell-test-wrong-image \
 	shell-test-pull-public \
 	shell-test-pull-private \
-	shell-test-push-local
+	shell-test-push-local-alpine
 
 shell-test-alpine:
 	./lstags alpine | egrep "\salpine:latest"
@@ -63,8 +63,8 @@ shell-test-pull-private: docker-json
 		echo "DOCKERHUB_PRIVATE_REPO or DOCKERHUB_AUTH not set!"; \
 	fi
 
-shell-test-push-local: REGISTRY_PORT:=5757
-shell-test-push-local:
+shell-test-push-local-alpine: REGISTRY_PORT:=5757
+shell-test-push-local-alpine:
 	${MAKE} --no-print-directory stop-local-registry &>/dev/null | true
 	${MAKE} --no-print-directory start-local-registry REGISTRY_PORT=${REGISTRY_PORT}
 	./lstags --push-registry=localhost:${REGISTRY_PORT} --push-prefix=/qa alpine~/3.6/

--- a/Makefile
+++ b/Makefile
@@ -32,18 +32,22 @@ docker-json:
 	test -n "${DOCKER_JSON}" && mkdir -p `dirname "${DOCKER_JSON}"` && touch "${DOCKER_JSON}" && chmod 0600 "${DOCKER_JSON}" \
 		&& echo "{ \"auths\": { \"registry.hub.docker.com\": { \"auth\": \"${DOCKERHUB_AUTH}\" } } }" >${DOCKER_JSON}
 
+start-local-registry: REGISTRY_PORT=5757
 start-local-registry:
-	test ${REGISTRY_PORT} && docker run -d -p ${REGISTRY_PORT}:5000 --name lstags-registry registry:2
+	docker rm -f lstags-registry &>/dev/null || true
+	docker run -d -p ${REGISTRY_PORT}:5000 --name lstags-registry registry:2
 
 stop-local-registry:
 	docker rm -f lstags-registry
 
-blackbox-integration-test: build \
+blackbox-integration-test: build start-local-registry \
 	shell-test-alpine \
 	shell-test-wrong-image \
 	shell-test-pull-public \
 	shell-test-pull-private \
-	shell-test-push-local-alpine
+	shell-test-push-local-alpine \
+	shell-test-push-local-assumed-tags \
+	stop-local-registry
 
 shell-test-alpine:
 	./lstags alpine | egrep "\salpine:latest"
@@ -63,13 +67,21 @@ shell-test-pull-private: docker-json
 		echo "DOCKERHUB_PRIVATE_REPO or DOCKERHUB_AUTH not set!"; \
 	fi
 
-shell-test-push-local-alpine: REGISTRY_PORT:=5757
+shell-test-push-local-alpine: REGISTRY_PORT=5757
 shell-test-push-local-alpine:
-	${MAKE} --no-print-directory stop-local-registry &>/dev/null | true
-	${MAKE} --no-print-directory start-local-registry REGISTRY_PORT=${REGISTRY_PORT}
 	./lstags --push-registry=localhost:${REGISTRY_PORT} --push-prefix=/qa alpine~/3.6/
 	./lstags localhost:${REGISTRY_PORT}/qa/library/alpine
-	${MAKE} --no-print-directory stop-local-registry
+
+shell-test-push-local-assumed-tags: REGISTRY_PORT=5757
+shell-test-push-local-assumed-tags:
+	@echo "NB! quay.io does not expose certain tags via API, so we need to 'believe' they exist."
+	./lstags --push-registry=localhost:${REGISTRY_PORT} --push-prefix=/qa quay.io/calico/cni~/^v1\\.[67]/
+	@echo "NB! Following command SHOULD fail, because no tags should be loaded without 'assumption'!"
+	./lstags localhost:${REGISTRY_PORT}/qa/calico/cni | egrep "v1\.(6\.1|7\.0)" && exit 1 || true
+	@echo "NB! Following command is assuming tags 'v1.6.1' and 'v1.7.0' do exist and will be loaded anyway."
+	./lstags --push-registry=localhost:${REGISTRY_PORT} --push-prefix=/qa quay.io/calico/cni~/^v1\\.[67]/=v1.6.1,v1.7.0
+	@echo "NB! This should NOT fail, because above we assumed tags 'v1.6.1' and 'v1.7.0' do exist."
+	./lstags localhost:${REGISTRY_PORT}/qa/calico/cni | egrep "v1\.(6\.1|7\.0)"
 
 lint: ERRORS=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -i golint {} | tr '`' '|')
 lint: fail-on-errors

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ lstags -P /quay -r registry.company.io quay.io/coreos/hyperkube quay.io/coreos/f
 * `ABSENT` - present in registry, but absent locally
 * `PRESENT` -  present in registry, present locally, with local and remote digests being equal
 * `CHANGED` - present in registry, present locally, but with **different** local and remote digests
+* `ASSUMED` - present in registry, not exposed to search but "injected" (assumed) manually by user
 * `LOCAL-ONLY` - present locally, absent in registry
 
 There is also special `UNKNOWN` state, which means `lstags` failed to detect image state for some reason.
@@ -54,6 +55,22 @@ There is also special `UNKNOWN` state, which means `lstags` failed to detect ima
 You can either:
 * rely on `lstags` discovering credentials "automagically" :tophat:
 * load credentials from any Docker JSON config file specified
+
+## Assume tags
+Sometimes registry may contain tags not exposed to any kind of search though still existing.
+`lstags` is unable to discover these tags, but if you need to pull or push them, you may "assume"
+they exist and make `lstags` blindly try to pull these tags from the registry. To inject assumed
+tags into the registry query you need to extend repository specification with a `=` followed by a
+comma-separated list of tags you want to assume.
+
+e.g. we assume tags `v1.6.1` and `v1.7.0` exist like this: `lstags quay.io/calico/cni=v1.6.1,v1.7.0`
+
+## Repository specification
+Full repository specification looks like this:
+```
+[REGISTRY[:PORT]/]REPOSITORY[~/FILTER_REGEXP/][=TAG1,TAG2,TAGn]
+```
+You may provide infinite number of repository specifications to `lstags`
 
 ## Install: Binaries
 https://github.com/ivanilves/lstags/releases

--- a/util/util.go
+++ b/util/util.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-const repoRefDesc = "repository[~/FILTER/][=tag1,tag2,tagN]"
+const repoRefDesc = "[REGISTRY[:PORT]/]REPOSITORY[~/FILTER_REGEXP/][=TAG1,TAG2,TAGn]"
 const repoRefExpr = "^[a-z0-9_][a-z0-9_\\-\\.\\/:]+[a-z0-9_](~\\/.*\\/)?(=.*)?$"
 
 const tagNameExpr = "^[a-z0-9_\\.\\-]+$"

--- a/util/util.go
+++ b/util/util.go
@@ -2,12 +2,90 @@ package util
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 )
 
+const repoRefDesc = "repository[~/FILTER/][=tag1,tag2,tagN]"
+const repoRefExpr = "^[a-z0-9_][a-z0-9_\\-\\.\\/:]+[a-z0-9_](~\\/.*\\/)?(=.*)?$"
+
+const tagNameExpr = "^[a-z0-9_\\.\\-]+$"
+
+// ParseRepoRef extracts:
+// * repository name
+// * tag filter
+// * assumed tag names (if any)
+// from the repo reference string passed
+func ParseRepoRef(repoRef string) (string, string, []string, error) {
+	if !DoesMatch(repoRef, repoRefExpr) {
+		err := errors.New(repoRef + " is not a valid repo spec: " + repoRefDesc)
+
+		return "", "", nil, err
+	}
+
+	repoWithFilter, assumedTagNames, err := SeparateAssumedTagNamesAndRepo(
+		repoRef,
+	)
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	repository, filter, err := SeparateFilterAndRepo(repoWithFilter)
+	if err != nil {
+		return repoWithFilter, "", assumedTagNames, err
+	}
+
+	for _, name := range assumedTagNames {
+		if !DoesMatch(name, filter) {
+			reason := fmt.Sprintf(
+				"Assumed tag '%s' does not match filter '%s', repo ref: %s",
+				name,
+				filter,
+				repoRef,
+			)
+
+			return repository, filter, assumedTagNames, errors.New(reason)
+		}
+	}
+
+	return repository, filter, assumedTagNames, nil
+}
+
+// SeparateAssumedTagNamesAndRepo separates repo ref from assumed tag names
+func SeparateAssumedTagNamesAndRepo(repoRef string) (string, []string, error) {
+	var reason string
+	parts := strings.Split(repoRef, "=")
+
+	repoWithFilter := parts[0]
+
+	if len(parts) < 2 {
+		return repoWithFilter, nil, nil
+	}
+
+	if len(parts) > 2 {
+		reason = "Unable to trim assumed tags from repo ref (too many '='!): "
+
+		return "", nil, errors.New(reason + repoRef)
+	}
+
+	assumedTagNames := strings.Split(parts[1], ",")
+
+	for _, name := range assumedTagNames {
+		if !DoesMatch(name, tagNameExpr) {
+			err := errors.New("Invalid tag name: " + name)
+
+			return repoWithFilter, nil, err
+		}
+	}
+
+	return repoWithFilter, assumedTagNames, nil
+}
+
 // SeparateFilterAndRepo separates repository name from optional regex filter
 func SeparateFilterAndRepo(repoWithFilter string) (string, string, error) {
+	var reason string
+
 	parts := strings.Split(repoWithFilter, "~")
 
 	repository := parts[0]
@@ -17,13 +95,17 @@ func SeparateFilterAndRepo(repoWithFilter string) (string, string, error) {
 	}
 
 	if len(parts) > 2 {
-		return "", "", errors.New("Unable to trim filter from repository (too many '~'!): " + repoWithFilter)
+		reason = "Unable to trim filter from repository (too many '~'!): "
+
+		return "", "", errors.New(reason + repoWithFilter)
 	}
 
 	f := parts[1]
 
 	if !strings.HasPrefix(f, "/") || !strings.HasSuffix(f, "/") {
-		return "", "", errors.New("Filter should be passed in a form: /REGEXP/")
+		reason = "Filter should be passed in a form: /REGEXP/: "
+
+		return "", "", errors.New(reason + repoWithFilter)
 	}
 
 	filter := f[1 : len(f)-1]


### PR DESCRIPTION
## WTF?
Some registries (`quay.io` reported) do not expose information about all tags for some repositories (`calico/cni` reported). So if we want to synchronize with them, but they "hide" interesting tags, we need to "assume" they have some tags they do not expose and just blindly get em! :roll_eyes: 

#### Example
We assume tags `v1.6.1` and `v1.7.0` exist like this: `lstags quay.io/calico/cni=v1.6.1,v1.7.0`

# GIF
![](https://media.giphy.com/media/ES4Vcv8zWfIt2/giphy.gif)