### PR TITLE
"Unhandicap" Pull and Push routines [ISSUE-144]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 
 # coverage reports
 *.coverprofile
+
+# dummy config.yaml for development and manual testing
+/config.yaml

--- a/api/registry/registry_test.go
+++ b/api/registry/registry_test.go
@@ -157,10 +157,13 @@ func TestSeedContainerWithImages(t *testing.T) {
 
 	for _, ref := range refs {
 		go func(ref string) {
-			if err := dockerClient.Pull(ref); err != nil {
+			resp, err := dockerClient.Pull(ref)
+			if err != nil {
 				done <- err
 				return
 			}
+
+			logDebugData(resp)
 
 			done <- nil
 		}(ref)


### PR DESCRIPTION
Following issue https://github.com/ivanilves/lstags/issues/144

### This PR has following objectives to achieve:
- [x] Remove useless Docker pull retries (Fail if needed, so what? Re-run `lstags`!)
- [ ] Add optional verbosity for Docker pull and push (should be done inside API log)
- [x] Ensure it is impossible for a single "unpullable" image to block application :scream: 

# GIF
![](https://media.giphy.com/media/3oz8xK9ER0CRMAhozK/giphy.gif)