### PR TITLE
IMPROVE: Tolerate errors on `Pull` and `Push` actions

### DIFF
--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -300,7 +300,7 @@ func (api *API) PullTags(cn *collection.Collection) error {
 		}(repo, tags, done)
 	}
 
-	return wait.Until(done)
+	return wait.WithTolerance(done)
 }
 
 // PushTags compares images from remote and "push" (usually local) registries,
@@ -357,7 +357,7 @@ func (api *API) PushTags(cn *collection.Collection, push PushConfig) error {
 		}(repo, tags, done)
 	}
 
-	return wait.Until(done)
+	return wait.WithTolerance(done)
 }
 
 func logDebugData(data io.Reader) {

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ type Options struct {
 	} `positional-args:"yes" required:"yes"`
 }
 
+var exitCode = 0
+
 var doNotFail = false
 
 func suicide(err error, critical bool) {
@@ -44,6 +46,8 @@ func suicide(err error, critical bool) {
 	if !doNotFail || critical {
 		os.Exit(1)
 	}
+
+	exitCode = 254 // not typical error code, for "git grep" friendliness
 }
 
 func parseFlags() (*Options, error) {
@@ -169,7 +173,7 @@ func main() {
 		}
 
 		if !o.DaemonMode {
-			os.Exit(0)
+			os.Exit(exitCode)
 		}
 
 		fmt.Printf("WAIT: %v\n-\n", o.PollingInterval)

--- a/util/wait/wait.go
+++ b/util/wait/wait.go
@@ -1,5 +1,7 @@
 package wait
 
+import "fmt"
+
 // Until iterates over buffered error channel and:
 // * upon receiving non-nil value from the channel, makes an early return with this value
 // * if no non-nil values were received from iteration over the channel, it just returns nil
@@ -20,4 +22,30 @@ func Until(done chan error) error {
 	}
 
 	return nil
+}
+
+// WithTolerance is the same as Until, but it does not return immediately on errors
+// rather loops through all channel capacity returning "composite" error in the end.
+func WithTolerance(done chan error) error {
+	var errMessage string
+
+	i := 0
+
+	for err := range done {
+		if err != nil {
+			errMessage = errMessage + err.Error() + "\n"
+		}
+
+		i++
+
+		if i >= cap(done) {
+			close(done)
+		}
+	}
+
+	if len(errMessage) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(errMessage)
 }


### PR DESCRIPTION
As stated in https://github.com/ivanilves/lstags/issues/146 we need to "try harder" while pulling or pushing Docker images.

This adds `wait.WithTolerance(done)` routine for pulls and pushes, so we will have errors logged and exit code set to non-zero, if something happens, but still most of the job will get done with "best effort" principle.