### PR TITLE
Fix nils and concurrent map writes

### DIFF
--- a/tag/remote/remote.go
+++ b/tag/remote/remote.go
@@ -109,8 +109,10 @@ func httpRetriableRequest(url, authorization, mode string) (*http.Response, erro
 			return resp, nil
 		}
 
-		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-			return nil, err
+		if resp != nil {
+			if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+				return nil, err
+			}
 		}
 
 		if try < tries {


### PR DESCRIPTION
Humbly trying to fix issues:
* https://github.com/ivanilves/lstags/issues/153 - do not use response if it is `nil` (we haven't stumbled upon this before because of pure luck)
* https://github.com/ivanilves/lstags/issues/154 - use `chan` instead of `map` while doing concurrent writes, as `chan` is kinda concurrency-safe