### PR TITLE
Add delay between batches & one more "concurrent map write" fix

### DIFF
--- a/api/v1/registry/container/container.go
+++ b/api/v1/registry/container/container.go
@@ -1,4 +1,4 @@
-package registry
+package container
 
 import (
 	"bufio"
@@ -78,8 +78,8 @@ func verify(hostname string) error {
 	return err
 }
 
-// LaunchContainer launches a Docker container with Docker registry inside
-func LaunchContainer() (*Container, error) {
+// Launch launches a Docker container with Docker registry inside
+func Launch() (*Container, error) {
 	dockerClient, _ := getDockerClient()
 
 	hostPort := getRandomPort()

--- a/api/v1/registry/container/container_test.go
+++ b/api/v1/registry/container/container_test.go
@@ -1,4 +1,4 @@
-package registry
+package container
 
 import (
 	"testing"
@@ -64,7 +64,7 @@ func TestRunGuaranteedFailure(t *testing.T) {
 }
 
 func testVerify(t *testing.T) {
-	c, _ := LaunchContainer()
+	c, _ := Launch()
 
 	defer c.Destroy()
 
@@ -81,8 +81,8 @@ func testVerifyGuaranteedFailure(t *testing.T) {
 	}
 }
 
-func TestLaunchContainerAndThanDestroyIt(t *testing.T) {
-	c, err := LaunchContainer()
+func TestLaunchAndThanDestroyIt(t *testing.T) {
+	c, err := Launch()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func TestLaunchManyContainersWithoutNamingCollisions(t *testing.T) {
 
 	for c := 0; c < createContainers; c++ {
 		go func() {
-			c, err := LaunchContainer()
+			c, err := Launch()
 			if err != nil {
 				done <- err
 				return
@@ -131,7 +131,7 @@ func TestLaunchManyContainersWithoutNamingCollisions(t *testing.T) {
 }
 
 func TestSeedContainerWithImages(t *testing.T) {
-	c, err := LaunchContainer()
+	c, err := Launch()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func TestSeedContainerWithImages(t *testing.T) {
 }
 
 func TestSeedContainerWithImagesGuaranteedFailure(t *testing.T) {
-	c, err := LaunchContainer()
+	c, err := Launch()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/api/v1/v1_test.go
+++ b/api/v1/v1_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/ivanilves/lstags/api/internal/registry"
+	registrycontainer "github.com/ivanilves/lstags/api/v1/registry/container"
 	"github.com/ivanilves/lstags/repository"
 )
 
@@ -28,7 +28,7 @@ func runEnd2EndJob(pullRefs, seedRefs []string) ([]string, error) {
 		return nil, err
 	}
 
-	registryContainer, err := registry.LaunchContainer()
+	registryContainer, err := registrycontainer.Launch()
 	if err != nil {
 		return nil, err
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ type Options struct {
 	PushPrefix         string        `short:"R" long:"push-prefix" description:"[Re]Push pulled images with a specified repo path prefix" env:"PUSH_PREFIX"`
 	PushUpdate         bool          `short:"U" long:"push-update" description:"Update our pushed images if remote image digest changes" env:"PUSH_UPDATE"`
 	ConcurrentRequests int           `short:"c" long:"concurrent-requests" default:"32" description:"Limit of concurrent requests to the registry" env:"CONCURRENT_REQUESTS"`
+	WaitBetween        time.Duration `short:"w" long:"wait-between" default:"0" description:"Time to wait between batches of requests (incl. pulls and pushes)" env:"WAIT_BETWEEN"`
 	RetryRequests      int           `short:"y" long:"retry-requests" default:"2" description:"Number of retries for failed Docker registry requests" env:"RETRY_REQUESTS"`
 	RetryDelay         time.Duration `short:"D" long:"retry-delay" default:"30s" description:"Delay between retries of failed registry requests" env:"RETRY_DELAY"`
 	InsecureRegistryEx string        `short:"I" long:"insecure-registry-ex" description:"Expression to match insecure registry hostnames" env:"INSECURE_REGISTRY_EX"`
@@ -99,6 +100,7 @@ func main() {
 	apiConfig := v1.Config{
 		DockerJSONConfigFile: o.DockerJSON,
 		ConcurrentRequests:   o.ConcurrentRequests,
+		WaitBetween:          o.WaitBetween,
 		TraceRequests:        o.TraceRequests,
 		RetryRequests:        o.RetryRequests,
 		RetryDelay:           o.RetryDelay,

--- a/tag/remote/remote.go
+++ b/tag/remote/remote.go
@@ -22,6 +22,9 @@ import (
 // ConcurrentRequests defines maximum number of concurrent requests we could maintain against the registry
 var ConcurrentRequests = 32
 
+// WaitBetween defines how much we will wait between batches of requests
+var WaitBetween time.Duration
+
 // RetryRequests is a number of retries we do in case of request failure
 var RetryRequests = 0
 
@@ -372,6 +375,8 @@ func FetchTags(repo *repository.Repository, username, password string) (map[stri
 			}(repo, tagNames[tagIndex], authorization, ch)
 
 			tagIndex++
+
+			time.Sleep(WaitBetween)
 		}
 
 		for s := 1; s <= stepSize; s++ {


### PR DESCRIPTION
I try to avoid non-single scope PR but ...

## What do we bring?
* `-w, --wait-between` CLI opt to wait between batches of requests (extra layer of self-DoS protection)
* fix another "concurrent map writes" issue (not funny anymore, raising importance of https://github.com/ivanilves/lstags/issues/143) https://github.com/ivanilves/lstags/issues/154
* move registry package from `internal` to `v1` namespace (a stupid chore to make me happy)

# GIF
![](https://media.giphy.com/media/IVDYYv6Cto6LS/giphy.gif)