### PR TITLE
test(api/v1/registry/container): Fix `TestRun` cleanup

### DIFF
--- a/api/v1/registry/container/container_test.go
+++ b/api/v1/registry/container/container_test.go
@@ -48,9 +48,12 @@ func TestRun(t *testing.T) {
 
 	port := getRandomPort()
 
-	if _, err := run(dc, port); err != nil {
+	id, err := run(dc, port)
+	if err != nil {
 		t.Fatal(err.Error())
 	}
+
+	dc.ForceRemove(id)
 }
 
 func TestRunGuaranteedFailure(t *testing.T) {


### PR DESCRIPTION
We forgot to cleanup Docker container in `TestRun`...