### PR TITLE
Add support to change PathSeperator

### DIFF
--- a/api/v1/registry/client/client.go
+++ b/api/v1/registry/client/client.go
@@ -113,11 +113,16 @@ func (cli *RegistryClient) Ping() error {
 func (cli *RegistryClient) Login(username, password string) error {
 	tk, err := auth.NewToken(cli.URL(), username, password, "registry:catalog:*")
 	if err != nil {
-		if username == "" && password == "" {
-			return nil
-		}
+		log.Debugf("Try to login with less permissions (repository:catalog:*)")
+		tk, err = auth.NewToken(cli.URL(), username, password, "repository:catalog:*")
 
-		return err
+		if err != nil {
+			if username == "" && password == "" {
+				return nil
+			}
+
+			return err
+		}
 	}
 
 	cli.Token = tk

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -5,11 +5,12 @@ package v1
 import (
 	"bufio"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"runtime"
 	"strings"
 	"time"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/ivanilves/lstags/api/v1/collection"
 	dockerclient "github.com/ivanilves/lstags/docker/client"
@@ -49,6 +50,8 @@ type PushConfig struct {
 	Registry string
 	// UpdateChanged tells us if we will re-push (update/overwrite) images having same tag, but different digest
 	UpdateChanged bool
+	// PathSeperator defines which path seperator to use (default: "/")
+	PathSeperator string
 }
 
 // API represents configured application API instance,
@@ -240,7 +243,7 @@ func (api *API) CollectPushTags(cn *collection.Collection, push PushConfig) (*co
 			pushRef := fmt.Sprintf(
 				"%s%s~/.*/",
 				push.Registry,
-				getPushPrefix(push.Prefix, repo.PushPrefix())+repo.Path(),
+				getPushPrefix(push.Prefix, repo.PushPrefix())+repo.PushPath(push.PathSeperator),
 			)
 
 			log.Debugf("%s 'push' reference: %+v", fn(repo.Ref()), pushRef)
@@ -382,7 +385,7 @@ func (api *API) PushTags(cn *collection.Collection, push PushConfig) error {
 		go func(repo *repository.Repository, tags []*tag.Tag, done chan error) {
 			for _, tg := range tags {
 				srcRef := repo.Name() + ":" + tg.Name()
-				dstRef := push.Registry + getPushPrefix(push.Prefix, repo.PushPrefix()) + repo.Path() + ":" + tg.Name()
+				dstRef := push.Registry + getPushPrefix(push.Prefix, repo.PushPrefix()) + repo.PushPath(push.PathSeperator) + ":" + tg.Name()
 
 				log.Infof("[PULL/PUSH] PUSHING %s => %s", srcRef, dstRef)
 

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -50,8 +50,8 @@ type PushConfig struct {
 	Registry string
 	// UpdateChanged tells us if we will re-push (update/overwrite) images having same tag, but different digest
 	UpdateChanged bool
-	// PathSeperator defines which path seperator to use (default: "/")
-	PathSeperator string
+	// PathSeparator defines which path separator to use (default: "/")
+	PathSeparator string
 }
 
 // API represents configured application API instance,
@@ -243,7 +243,7 @@ func (api *API) CollectPushTags(cn *collection.Collection, push PushConfig) (*co
 			pushRef := fmt.Sprintf(
 				"%s%s~/.*/",
 				push.Registry,
-				getPushPrefix(push.Prefix, repo.PushPrefix())+repo.PushPath(push.PathSeperator),
+				getPushPrefix(push.Prefix, repo.PushPrefix())+repo.PushPath(push.PathSeparator),
 			)
 
 			log.Debugf("%s 'push' reference: %+v", fn(repo.Ref()), pushRef)
@@ -385,7 +385,7 @@ func (api *API) PushTags(cn *collection.Collection, push PushConfig) error {
 		go func(repo *repository.Repository, tags []*tag.Tag, done chan error) {
 			for _, tg := range tags {
 				srcRef := repo.Name() + ":" + tg.Name()
-				dstRef := push.Registry + getPushPrefix(push.Prefix, repo.PushPrefix()) + repo.PushPath(push.PathSeperator) + ":" + tg.Name()
+				dstRef := push.Registry + getPushPrefix(push.Prefix, repo.PushPrefix()) + repo.PushPath(push.PathSeparator) + ":" + tg.Name()
 
 				log.Infof("[PULL/PUSH] PUSHING %s => %s", srcRef, dstRef)
 

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jessevdk/go-flags"
 
-	"github.com/ivanilves/lstags/api/v1"
+	v1 "github.com/ivanilves/lstags/api/v1"
 	"github.com/ivanilves/lstags/config"
 )
 
@@ -21,6 +21,7 @@ type Options struct {
 	PushRegistry       string        `short:"r" long:"push-registry" description:"[Re]Push pulled images to a specified remote registry" env:"PUSH_REGISTRY"`
 	PushPrefix         string        `short:"R" long:"push-prefix" description:"[Re]Push pulled images with a specified repo path prefix" env:"PUSH_PREFIX"`
 	PushUpdate         bool          `short:"U" long:"push-update" description:"Update our pushed images if remote image digest changes" env:"PUSH_UPDATE"`
+	PathSeperator      string        `short:"s" long:"path-seperator" default:"/" description:"Configure path seperator for registries that only allow single folder depth" env:"PATH_SEPERATOR"`
 	ConcurrentRequests int           `short:"c" long:"concurrent-requests" default:"32" description:"Limit of concurrent requests to the registry" env:"CONCURRENT_REQUESTS"`
 	WaitBetween        time.Duration `short:"w" long:"wait-between" default:"0" description:"Time to wait between batches of requests (incl. pulls and pushes)" env:"WAIT_BETWEEN"`
 	RetryRequests      int           `short:"y" long:"retry-requests" default:"2" description:"Number of retries for failed Docker registry requests" env:"RETRY_REQUESTS"`
@@ -162,6 +163,7 @@ func main() {
 				Registry:      o.PushRegistry,
 				Prefix:        o.PushPrefix,
 				UpdateChanged: o.PushUpdate,
+				PathSeperator: o.PathSeperator,
 			}
 
 			pushCollection, err := api.CollectPushTags(collection, pushConfig)

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ type Options struct {
 	PushRegistry       string        `short:"r" long:"push-registry" description:"[Re]Push pulled images to a specified remote registry" env:"PUSH_REGISTRY"`
 	PushPrefix         string        `short:"R" long:"push-prefix" description:"[Re]Push pulled images with a specified repo path prefix" env:"PUSH_PREFIX"`
 	PushUpdate         bool          `short:"U" long:"push-update" description:"Update our pushed images if remote image digest changes" env:"PUSH_UPDATE"`
-	PathSeperator      string        `short:"s" long:"path-seperator" default:"/" description:"Configure path seperator for registries that only allow single folder depth" env:"PATH_SEPERATOR"`
+	PathSeparator      string        `short:"s" long:"path-separator" default:"/" description:"Configure path separator for registries that only allow single folder depth" env:"PATH_SEPARATOR"`
 	ConcurrentRequests int           `short:"c" long:"concurrent-requests" default:"32" description:"Limit of concurrent requests to the registry" env:"CONCURRENT_REQUESTS"`
 	WaitBetween        time.Duration `short:"w" long:"wait-between" default:"0" description:"Time to wait between batches of requests (incl. pulls and pushes)" env:"WAIT_BETWEEN"`
 	RetryRequests      int           `short:"y" long:"retry-requests" default:"2" description:"Number of retries for failed Docker registry requests" env:"RETRY_REQUESTS"`
@@ -163,7 +163,7 @@ func main() {
 				Registry:      o.PushRegistry,
 				Prefix:        o.PushPrefix,
 				UpdateChanged: o.PushUpdate,
-				PathSeperator: o.PathSeperator,
+				PathSeparator: o.PathSeparator,
 			}
 
 			pushCollection, err := api.CollectPushTags(collection, pushConfig)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -89,6 +89,15 @@ func (r *Repository) Path() string {
 	return path
 }
 
+// PushPath gives us sanitized repository path and checks if subdirectories are allowed
+func (r *Repository) PushPath(pathSeperator string) string {
+	path := r.Path()
+
+	path = strings.Join(strings.Split(path, "/"), pathSeperator)
+
+	return path
+}
+
 // HasTags tells us if we've specified some concrete tags for this repository
 func (r *Repository) HasTags() bool {
 	return r.repoTags != nil && len(r.repoTags) != 0

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -89,11 +89,11 @@ func (r *Repository) Path() string {
 	return path
 }
 
-// PushPath gives us sanitized repository path and checks if subdirectories are allowed
-func (r *Repository) PushPath(pathSeperator string) string {
+// PushPath returns a repository path with a custom path element separator
+func (r *Repository) PushPath(pathSeparator string) string {
 	path := r.Path()
 
-	path = strings.Join(strings.Split(path, "/"), pathSeperator)
+	path = strings.Join(strings.Split(path, "/"), pathSeparator)
 
 	return path
 }


### PR DESCRIPTION
Hey,

I encountered the problem that my registry does not support arbitrary paths for images.

To counter this I added support to exchange "/" with any customizable seperator via cli.

I also had an issue with the login on my quay enterprise registry, hence why I needed to change api/v1/registry/client/client.go:114 to use repository instead of registry. 

Kind regards