### PR TITLE
Set path separator in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ lint: fail-on-errors
 vet: ERRORS=$(shell find . -name "*.go" ! -path "./vendor/*" | xargs -I {} go tool vet {} | tr '`' '|')
 vet: fail-on-errors
 
-semantic: REGEX:="^(feat|fix|docs|style|refactor|test|chore)(\([a-zA-Z0-9\_\-\/]+\))?: [A-Z]"
+semantic: REGEX:="^(feat|fix|docs|style|refactor|test|chore|localize)(\([a-zA-Z0-9\_\-\/]+\))?: [a-zA-Z]"
 semantic:
 	@if [[ -n "${RANGE}" ]]; then \
 		git log --pretty="format:%s" ${RANGE} \

--- a/api/v1/v1_test.go
+++ b/api/v1/v1_test.go
@@ -41,7 +41,7 @@ func runEnd2EndJob(pullRefs, seedRefs []string) ([]string, error) {
 		}
 	}
 
-	pushConfig := PushConfig{Registry: registryContainer.Hostname()}
+	pushConfig := PushConfig{Registry: registryContainer.Hostname(), PathSeparator: "/"}
 
 	pushCollection, err := api.CollectPushTags(collection, pushConfig)
 	if err != nil {


### PR DESCRIPTION
In https://github.com/ivanilves/lstags/pull/179 we added path separator support 💪, but we forgot to explain it to our testing suite. Fixing it!