### PR TITLE
fix: remove "filter" part from ref spec

### DIFF
--- a/api/v1/v1_test.go
+++ b/api/v1/v1_test.go
@@ -94,6 +94,12 @@ func TestEnd2End(t *testing.T) {
 			true,
 		},
 		{
+			[]string{"alpine:3.7", "rocket.chat:2"},
+			[]string{"alpine:3.7"},
+			[]string{"rocket.chat:2"},
+			true,
+		},
+		{
 			[]string{"idonotexist:latest", "busybox:latest"},
 			[]string{},
 			[]string{},

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -211,6 +211,8 @@ func isHostname(s string) bool {
 
 // GetRegistry extracts registry address from the repository reference
 func GetRegistry(ref string) string {
+	ref = strings.Split(ref, "~")[0]
+
 	if !strings.Contains(ref, "/") {
 		return defaultRegistry
 	}


### PR DESCRIPTION
Remove "filter" part from ref spec before parsing it - to not confuse parser. Fixes https://github.com/ivanilves/lstags/issues/199