### PR TITLE
Fix pagination bug #225 and fix tests on Ubuntu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
       - run:
           name: Build release assets and binaries
           command: |
+            git reset --hard
             make release
 
             ./dist/assets/lstags-linux/lstags --version

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ unit-test:
 	@find . \
 		-mindepth 2 -type f ! -path "./vendor/*" ! -path "./api/*" -name "*_test.go" \
 		| xargs -I {} dirname {} \
-		| xargs -I {} sh -c "pushd {}; go test -v -cover || exit 1; popd"
+		| xargs -I {} bash -c "pushd {}; go test -v -cover || exit 1; popd"
 
 whitebox-integration-test:
 	@find . \
 		-mindepth 2 -type f -path "./api/*" -name "*_test.go" \
 		| xargs -I {} dirname {} \
-		| xargs -I {} sh -c "pushd {}; go test -v -cover || exit 1; popd"
+		| xargs -I {} bash -c "pushd {}; go test -v -cover || exit 1; popd"
 
 coverage: PROJECT:=github.com/ivanilves/lstags
 coverage: SERVICE:=ci

--- a/api/v1/registry/client/request/request.go
+++ b/api/v1/registry/client/request/request.go
@@ -124,7 +124,7 @@ func getNextLink(headers []string) string {
 	nextlink := headers[0]
 
 	nextlink = strings.Split(nextlink, "?")[1]
-	nextlink = strings.Split(nextlink, ";")[0]
+	nextlink = strings.Split(nextlink, ">")[0]
 
 	return nextlink
 }


### PR DESCRIPTION
Close #225 

I'm pretty certain this is all that's required to fix the pagination problems I was seeing with quay.io. I've also changed the tests to use bash instead of sh, as pushd and popd are only available in bash...at least on my Ubuntu 20.04 machine.