### PR TITLE
Fix incorrectly hardcoded Docker Authentication username

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
       - run:
           name: Build release assets and binaries
           command: |
+            git reset --hard
             make release
 
             ./dist/assets/lstags-linux/lstags --version

--- a/docker/config/config.go
+++ b/docker/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/ivanilves/lstags/docker/config/credhelper"
 	"github.com/moby/moby/api/types"
 
@@ -56,7 +57,7 @@ func (c *Config) GetCredentials(registry string) (string, string, bool) {
 
 func getAuthJSONString(username, password string) string {
 	b, err := json.Marshal(types.AuthConfig{
-		Username: "_json_key",
+		Username: username,
 		Password: password,
 	})
 
@@ -76,9 +77,11 @@ func (c *Config) GetRegistryAuth(registry string) string {
 	if !defined {
 		return ""
 	}
+	authJSONString := getAuthJSONString(username, password)
+	log.Debugf("JSON Auth String: %s", authJSONString)
 
 	return base64.StdEncoding.EncodeToString(
-		[]byte(getAuthJSONString(username, password)),
+		[]byte(authJSONString),
 	)
 }
 

--- a/docker/config/config_test.go
+++ b/docker/config/config_test.go
@@ -10,8 +10,8 @@ var configFile = "../../fixtures/docker/config.json"
 
 func TestGetRegistryAuth(t *testing.T) {
 	examples := map[string]string{
-		"registry.company.io":     "eyJ1c2VybmFtZSI6Il9qc29uX2tleSIsInBhc3N3b3JkIjoicGFzczEifQ==",
-		"registry.hub.docker.com": "eyJ1c2VybmFtZSI6Il9qc29uX2tleSIsInBhc3N3b3JkIjoicGFzczIifQ==",
+		"registry.company.io":     "eyJ1c2VybmFtZSI6InVzZXIxIiwicGFzc3dvcmQiOiJwYXNzMSJ9",
+		"registry.hub.docker.com": "eyJ1c2VybmFtZSI6InVzZXIyIiwicGFzc3dvcmQiOiJwYXNzMiJ9",
 		"registry.mindundi.org":   "",
 	}
 


### PR DESCRIPTION
I could not get the latest version to push to my Amazon ECR registry and it seems to be because of this hardcoded `_json_key` username. I believe this is probably a separate issue to #214 because the breaking change was only introduced in v1.2.16.

I have also had to tweak the "Build release assets and binaries" Circle CI step to allow the build to succeed.

Thanks!