### PR TITLE
fix(repository): ensure we parse docker.io repos correctly

### DIFF
--- a/repository/repository.go
+++ b/repository/repository.go
@@ -37,6 +37,7 @@ var validRefExprs = map[string]*regexp.Regexp{
 }
 
 const defaultRegistry = "registry.hub.docker.com"
+const fakeRegistry = "docker.io"
 
 // Repository is a parsed, valid Docker repository reference
 type Repository struct {
@@ -84,6 +85,10 @@ func (r *Repository) Path() string {
 
 	if r.IsDefaultRegistry() && !strings.Contains(path, "/") {
 		return "library/" + path
+	}
+
+	if strings.HasPrefix(path, fakeRegistry+"/") {
+		return strings.TrimPrefix(path, fakeRegistry+"/")
 	}
 
 	return path
@@ -220,6 +225,10 @@ func GetRegistry(ref string) string {
 	registry := strings.Split(ref, "/")[0]
 
 	if isHostname(registry) {
+		if registry == fakeRegistry {
+			return defaultRegistry
+		}
+
 		return registry
 	}
 
@@ -269,7 +278,7 @@ func ParseRef(ref string) (*Repository, error) {
 		fullRepo = refParts[0]
 		filterRE = regexp.MustCompile(refParts[1][1 : len(refParts[1])-1])
 	default:
-		return nil, fmt.Errorf("unknown repository  reference specification: %s", spec)
+		return nil, fmt.Errorf("unknown repository reference specification: %s", spec)
 	}
 
 	return &Repository{

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -21,18 +21,19 @@ func TestParseRef(t *testing.T) {
 	}
 
 	var testCases = map[string]expectation{
-		"alpine":                                {"registry.hub.docker.com", true, "registry.hub.docker.com/alpine", "alpine", "library/alpine", []string{}, ".*", "https://", false, true},
-		"alp@ne":                                {"", true, "", "", "", []string{}, "", "", false, false},
-		"localhost/bitcoin/robot":               {"localhost", false, "localhost/bitcoin/robot", "localhost/bitcoin/robot", "bitcoin/robot", []string{}, ".*", "http://", false, true},
-		"localhost:5000/nada/mindundi":          {"localhost:5000", false, "localhost:5000/nada/mindundi", "localhost:5000/nada/mindundi", "nada/mindundi", []string{}, ".*", "http://", false, true},
-		"localhost:7eff/nada/mindundi":          {"", true, "", "", "", []string{}, "", "", false, false},
-		"quay.io/coreos/awscli:master":          {"quay.io", false, "quay.io/coreos/awscli", "quay.io/coreos/awscli", "coreos/awscli", []string{"master"}, "", "https://", true, true},
-		"registry.org/some/repo=latest,stable":  {"registry.org", false, "registry.org/some/repo", "registry.org/some/repo", "some/repo", []string{"latest", "stable"}, "", "https://", true, true},
-		"registry.org/some/repo=lat!st,stable":  {"", true, "", "", "", []string{}, "", "", false, false},
-		"registry.org/some/repo~/^v1/":          {"registry.org", false, "registry.org/some/repo", "registry.org/some/repo", "some/repo", []string{}, "^v1", "https://", false, true},
-		"registry.org/some/repo~|^v1|":          {"", true, "", "", "", []string{}, "", "", false, false},
-		"ivanilves/lstags":                      {"registry.hub.docker.com", true, "registry.hub.docker.com/ivanilves/lstags", "ivanilves/lstags", "ivanilves/lstags", []string{}, ".*", "https://", false, true},
-		"quay.io/coreos/flannel:v0.6.1-ppc64le": {"quay.io", false, "quay.io/coreos/flannel", "quay.io/coreos/flannel", "coreos/flannel", []string{"v0.6.1-ppc64le"}, "", "https://", true, true},
+		"alpine":                                          {"registry.hub.docker.com", true, "registry.hub.docker.com/alpine", "alpine", "library/alpine", []string{}, ".*", "https://", false, true},
+		"alp@ne":                                          {"", true, "", "", "", []string{}, "", "", false, false},
+		"localhost/bitcoin/robot":                         {"localhost", false, "localhost/bitcoin/robot", "localhost/bitcoin/robot", "bitcoin/robot", []string{}, ".*", "http://", false, true},
+		"localhost:5000/nada/mindundi":                    {"localhost:5000", false, "localhost:5000/nada/mindundi", "localhost:5000/nada/mindundi", "nada/mindundi", []string{}, ".*", "http://", false, true},
+		"localhost:7eff/nada/mindundi":                    {"", true, "", "", "", []string{}, "", "", false, false},
+		"quay.io/coreos/awscli:master":                    {"quay.io", false, "quay.io/coreos/awscli", "quay.io/coreos/awscli", "coreos/awscli", []string{"master"}, "", "https://", true, true},
+		"registry.org/some/repo=latest,stable":            {"registry.org", false, "registry.org/some/repo", "registry.org/some/repo", "some/repo", []string{"latest", "stable"}, "", "https://", true, true},
+		"registry.org/some/repo=lat!st,stable":            {"", true, "", "", "", []string{}, "", "", false, false},
+		"registry.org/some/repo~/^v1/":                    {"registry.org", false, "registry.org/some/repo", "registry.org/some/repo", "some/repo", []string{}, "^v1", "https://", false, true},
+		"registry.org/some/repo~|^v1|":                    {"", true, "", "", "", []string{}, "", "", false, false},
+		"ivanilves/lstags":                                {"registry.hub.docker.com", true, "registry.hub.docker.com/ivanilves/lstags", "ivanilves/lstags", "ivanilves/lstags", []string{}, ".*", "https://", false, true},
+		"quay.io/coreos/flannel:v0.6.1-ppc64le":           {"quay.io", false, "quay.io/coreos/flannel", "quay.io/coreos/flannel", "coreos/flannel", []string{"v0.6.1-ppc64le"}, "", "https://", true, true},
+		"docker.io/bitnami/zookeeper:3.6.1-debian-10-r37": {"registry.hub.docker.com", true, "registry.hub.docker.com/docker.io/bitnami/zookeeper", "docker.io/bitnami/zookeeper", "bitnami/zookeeper", []string{"3.6.1-debian-10-r37"}, "", "https://", true, true},
 	}
 
 	assert := assert.New(t)


### PR DESCRIPTION
closes https://github.com/ivanilves/lstags/issues/224

:information_source: `docker.io` is a fake fancy name for `registry.hub.docker.com`